### PR TITLE
Added require cairo_xlib to abstract.lua, Wayland compatibility fix

### DIFF
--- a/abstract.lua
+++ b/abstract.lua
@@ -8,6 +8,7 @@
 ----------------------------------
 
 require("cairo")
+require("cairo_xlib")
 require("imlib2")
 require("settings")
 


### PR DESCRIPTION
Due to upstream updates, added cairo_xlib to list of requires.

See https://github.com/brndnmtthws/conky/issues/1867 